### PR TITLE
Add txt files support, fix requirements, add ssl check

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ optional arguments:
   -n NAME, --name NAME  name of the individual person or company to look up.
   -d, --display         print results to console.
   -s, --save            save results to JSON format.
+  -t [{json,txt}], --type [{json,txt}]
+                        set file type: 'json' or 'txt'. Default: 'json'.
 ```
 
 ### Example
@@ -100,6 +102,7 @@ test-acme.com
 thehfg.co.uk
 xiaoweilu.cn
 [:] Saving results to JSON file...
+[:] Saved to domains.json
 [:] Found 73 printable domains!
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-#pandas==0.23.4
-pandas
-argparse
+pandas==0.23.4
+lxml==4.2.5
+html5lib==1.0.1
+BeautifulSoup4==4.6.3


### PR DESCRIPTION
**Issue #1** 
Added `txt` files support. Domain names will be written in `domains.txt` file line by line.
For use this you can set flag `-t` with `txt` value. By default - script uses `json`

As well i added necessary requirements. Without this requirements `k2.py` cannot start. And added check for `ssl`(without that in some cases script failing on `result = pd.read_html(url)`)